### PR TITLE
Add support for shell version 49

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,5 +3,5 @@
   "description": "Automatically paste Emojis from the Smile emoji picker",
   "uuid": "smile-extension@mijorus.it",
   "url": "https://github.com/mijorus/smile-gnome-extension",
-  "shell-version": ["45", "46", "47","48"]
+  "shell-version": ["45", "46", "47", "48", "49"]
 }


### PR DESCRIPTION
No breaking changes w.r.t. this extension - tried out using following command - and it worked!

    gnome-extensions install --force smile-gnome-extension-patch-1.zip